### PR TITLE
PC-182 | Build Acquia acquia-puppet for Ubuntu 20

### DIFF
--- a/lib/puppet/util/monkey_patches.rb
+++ b/lib/puppet/util/monkey_patches.rb
@@ -175,7 +175,9 @@ class OpenSSL::SSL::SSLContext
   else
     DEFAULT_PARAMS[:options] = OpenSSL::SSL::OP_NO_SSLv2 | OpenSSL::SSL::OP_NO_SSLv3
   end
-  DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+  if DEFAULT_PARAMS[:ciphers]
+    DEFAULT_PARAMS[:ciphers] << ':!SSLv2'
+  end
 
   alias __original_initialize initialize
   private :__original_initialize


### PR DESCRIPTION
Cherry picked the **DEFAULT_PARAMS[:ciphers]**  with **SSLv2** change https://github.com/puppetlabs/puppet/pull/5911/commits/fc7c1aaf60062746d463de97d5d0c2bee7fb7199 from the puppetlabs